### PR TITLE
postリクエストのLocotionヘッダを指定できるように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,40 @@ https://qiita.com/os1ma/items/25725edfe3c2af93d735
 - Serviceに渡すデータへの変換処理(Bean変換、型変換、形式変換など)は、ServiceではなくController側で行う。
 - ビジネスルールに関わる処理はServiceで行う。業務データへのアクセスは、RepositoryまたはO/R Mapperに委譲する。
 - ServiceからControllerに返却するデータ（クライアントへレスポンスするデータ）に対する値の変換処理(型変換、形式変換など)は、Serviceではなく、Controller側（Viewクラスなど）で行う。  
+## 【ユーザー登録APIのControllerの処理について】
+### **小山先生課題**
+- .path("/users/id") ですがidの箇所は登録処理によって新たに採番されたユーザーのidを設定するようにしてください
+  /users/1 のようになるイメージです
+- http://localhost:8080のようにハードコードするのでなく動的にhostを取得できるようにしましょう
+- curlまたはPostmanを使って動作確認するときにレスポンスヘッダーにLocation: http://localhost:8080/users/1 のように新規作成されたリソースへのURLがLocationヘッダーとして登録されていることを確認してください
+- PRの概要にLocationヘッダーを指定する理由を考えて記載お願いします。
+
+**理解**
+- 登録処理によって新しく採番されたユーザーidを設定するようにする
+- URLを動的に取得(変化に強いコードを書く)
+- それらがきちんと設定されているかPostmanで動作を確認
+- PR概要に「なぜLocationヘッダーを指定するのか」を記載
+
+### **そもそもUriComponentsBuilderとは**
+```
+URIの構築を簡単に出来るやつ 
+```
+**URIとは？**  
+Uniform Resource Identifierの略  
+一定の書式によってリソース(資源)を指し示す識別子
+## **UriComponentsBuilder**
+```
+1.静的ファクトリメソッドの 1 つで UriComponentsBuilder を作成する (fromPath(String) や fromUri(URI) など)   
+2.それぞれのメソッド（scheme(String)、userInfo(String)、host(String)、port(int)、path(String)、pathSegment(String...)、queryParam(String, Object...)、fragment(String) を介してさまざまな URI コンポーネントを設定します。  
+3.build() メソッドを使用して UriComponents インスタンスを構築します。
+```
+**静的ファクトリメソッド**  
+インスタンスを返す単なる static メソッドのこと
+
+## 何故Locationヘッダを指定するのか
+フォームの入力ミスをその場でユーザにフィードバックしたい    
+入力が正しい場合のみ Location ヘッダによってリダイレクトする，という構造にするとわかりやすいから  
+
+
 
 

--- a/src/main/java/com/raisetech/crudsample/controller/UserController.java
+++ b/src/main/java/com/raisetech/crudsample/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
     @PostMapping//バリデーション:nameに@NotEmpty
     public ResponseEntity<String> insertUser(@RequestBody InsertForm insertForm,UriComponentsBuilder uriComponentsBuilder) {
         userService.insertUser(insertForm);
-        URI uri = uriComponentsBuilder.path("/users/{id}").buildAndExpand().toUri();
+        URI uri = uriComponentsBuilder.path("/users/{id}").build().toUri();
         return ResponseEntity.created(uri).body("name successfully created");
     }
 

--- a/src/main/java/com/raisetech/crudsample/controller/UserController.java
+++ b/src/main/java/com/raisetech/crudsample/controller/UserController.java
@@ -33,10 +33,9 @@ public class UserController {
     }
 
     @PostMapping//バリデーション:nameに@NotEmpty
-    public ResponseEntity<String> insertUser(@RequestBody InsertForm insertForm) {
+    public ResponseEntity<String> insertUser(@RequestBody InsertForm insertForm,UriComponentsBuilder uriComponentsBuilder) {
         userService.insertUser(insertForm);
-        URI uri = UriComponentsBuilder.fromUriString("http://localhost:8080")
-                .path("/users/id").build().toUri();
+        URI uri = uriComponentsBuilder.path("/users/{id}").buildAndExpand().toUri();
         return ResponseEntity.created(uri).body("name successfully created");
     }
 

--- a/src/main/java/com/raisetech/crudsample/form/InsertForm.java
+++ b/src/main/java/com/raisetech/crudsample/form/InsertForm.java
@@ -7,7 +7,6 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Getter
 @Setter
-
 public class InsertForm {
     private String name;
     private int id;

--- a/src/main/java/com/raisetech/crudsample/form/InsertForm.java
+++ b/src/main/java/com/raisetech/crudsample/form/InsertForm.java
@@ -1,5 +1,6 @@
 package com.raisetech.crudsample.form;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -7,7 +8,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 @Getter
 @Setter
+@AllArgsConstructor
 public class InsertForm {
-    private String name;
     private int id;
+    private String name;
 }

--- a/src/main/java/com/raisetech/crudsample/form/InsertForm.java
+++ b/src/main/java/com/raisetech/crudsample/form/InsertForm.java
@@ -1,10 +1,14 @@
 package com.raisetech.crudsample.form;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Getter
 @Setter
+
 public class InsertForm {
     private String name;
+    private int id;
 }

--- a/src/main/java/com/raisetech/crudsample/service/UserServiceImpl.java
+++ b/src/main/java/com/raisetech/crudsample/service/UserServiceImpl.java
@@ -40,6 +40,5 @@ public class UserServiceImpl implements UserService {
     @Override
     public void deleteUser(int id) {
         userMapper.deleteUser(id);
-
     }
 }


### PR DESCRIPTION
お世話になります！
### 小山先生課題に取り組みました  
- .path("/users/id") ですがidの箇所は登録処理によって新たに採番されたユーザーのidを設定するようにしてください( /users/1 のようになるイメージです)
- http://localhost:8080のようにハードコードするのでなく動的にhostを取得できるようにしましょう
- curlまたはPostmanを使って動作確認するときにレスポンスヘッダーにLocation: http://localhost:8080/users/1 のように新規作成されたリソースへのURLがLocationヘッダーとして登録されていることを確認してください
- PRの概要にLocationヘッダーを指定する理由を考えて記載お願いします。

動的にhostを取得するところまでは出来ました。
users/{id}部分ににAUTO_INCREMENTしたidを取得したいのですがやり方が分かりません。  
### どうやら.buildAndExpand()の引数に自動採番したidを入れれば良さそう  
ということろまでは分かりました。今はまだこのような状態です。  
<img width="614" alt="スクリーンショット 2022-09-12 230840" src="https://user-images.githubusercontent.com/107123973/189675458-8bca8c69-76b4-4776-bf16-ce3ea8363137.png">  
なにかヒントを頂けないでしょうか。

**Locationヘッダを指定する理由**は、成功した時だけLocationヘッダにリダイレクトする設計にすると、ユーザーに結果をフィードバックすることが出来てわかりやすからだと思いました。